### PR TITLE
Included Mac in Travis CI and got Unit Tests to pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ jobs:
       env: PYTHON=38
     - name: "Python 3.6 on macOS"
       os: osx
-      osx_image: xcode11.2  
+      osx_image: xcode11.2
       language: shell       # 'language: python' is an error on Travis CI macOS
       env: PYTHON=36
 cache:
@@ -35,30 +35,38 @@ addons:
             - libhdf5-dev
 
 install:
+    #set python version
+    pip install -upgrade pip
+    pip install --egg --no-binary pyenv pyenv
+    export PATH=~/.pyenv/bin:$PATH
+    eval "$(pyenv init -)"
+    pyenv install --skip-existing $PYTHON
+    pyenv global $PYTHON
+    pyenv shell $PYTHON
     # Upgrade distribution modules
-    - "pip3 install --upgrade setuptools"
-    - "pip3 install --upgrade pip"
+    - "pip install --upgrade setuptools"
+    - "pip install --upgrade pip"
 
     # Install build dependencies
-    - "pip3 install wheel"
-    - "pip3 install --trusted-host www.silx.org -r ci/requirement_travis.txt --upgrade --find-links http://www.silx.org/pub/wheelhouse"
+    - "pip install wheel"
+    - "pip install --trusted-host www.silx.org -r ci/requirement_travis.txt --upgrade --find-links http://www.silx.org/pub/wheelhouse"
 
     # Print Python info
-    - "python3 ci/info_platform.py"
-    - "pip3 freeze"
+    - "python ci/info_platform.py"
+    - "pip freeze"
 
     # Build
-    - "python3 setup.py build"
-    - "python3 setup.py bdist_wheel"
+    - "python setup.py build"
+    - "python setup.py bdist_wheel"
     - "ls dist"
 
     # Install generated wheel
-    - "pip3 install --pre --find-links dist/ --trusted-host www.silx.org --find-links http://www.silx.org/pub/wheelhouse freesas"
+    - "pip install --pre --find-links dist/ --trusted-host www.silx.org --find-links http://www.silx.org/pub/wheelhouse freesas"
 
 script:
     # Print Python info
-    - "python3 ci/info_platform.py"
-    - "pip3 freeze"
+    - "python ci/info_platform.py"
+    - "pip freeze"
 
     # Run the tests
     - "python3 setup.py build test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,17 +9,17 @@ jobs:
       python: 3.7   # this works for Linux but is ignored on macOS or Windows
     - name: "Python 3.8.0 on Xenial Linux"
       python: 3.8  # this works for Linux but is ignored on macOS or Windows
-    - name: "Python 3.7.4 on macOS"
+    - name: "xcode 9.4 on macOS"
       os: osx
-      osx_image: xcode11.2  # Python 3.7.4 running on macOS 10.14.4
+      osx_image: xcode9.4
       language: shell       # 'language: python' is an error on Travis CI macOS
     - name: "xcode 11.2 on macOS"
       os: osx
-      osx_image: xcode11.2  # Python 3.7.4 running on macOS 10.14.4
+      osx_image: xcode11.2
       language: shell       # 'language: python' is an error on Travis CI macOS
     - name: "xcode 10.2 on macOS"
       os: osx
-      osx_image: xcode10.2  # Python 3.7.4 running on macOS 10.14.4
+      osx_image: xcode10.2
       language: shell       # 'language: python' is an error on Travis CI macOS
 
 
@@ -59,6 +59,8 @@ script:
     # Print Python info
     - "python3 ci/info_platform.py"
     - "pip3 freeze"
+    - "python3 -- version"
+    - "gcc --version"
 
     # Run the tests
     - "python3 setup.py build test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ addons:
 
 install:
     #set python version
-    - "pip install -upgrade pip"
+    - "pip install --upgrade pip"
     - "pip install --egg --no-binary pyenv pyenv"
     - "export PATH=~/.pyenv/bin:$PATH"
     - "eval '$(pyenv init -)'"

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,14 +38,7 @@ addons:
             - libhdf5-dev
 
 install:
-    #set python version
-    pip install -upgrade pip
-    pip install --egg --no-binary pyenv pyenv
-    export PATH=~/.pyenv/bin:$PATH
-    eval "$(pyenv init -)"
-    pyenv install --skip-existing $PYTHON
-    pyenv global $PYTHON
-    pyenv shell $PYTHON
+
     # Upgrade distribution modules
     - "pip install --upgrade setuptools"
     - "pip install --upgrade pip"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,18 +17,31 @@ jobs:
       osx_image: xcode11.2  # Python 3.7.4 running on macOS 10.14.4
       language: shell       # 'language: python' is an error on Travis CI macOS
       env: PYTHON=3.7.4
+      before_install:
+        - brew install pyenv
+        - "export PATH=~/.pyenv/bin:$PATH"
+        - "eval '$(pyenv init -)'"
+        - "pyenv install --skip-existing $PYTHON"
+        - "pyenv global $PYTHON"
+        - "pyenv shell $PYTHON"
     - name: "Python 3.8 on macOS"
       os: osx
       osx_image: xcode11.2
       language: shell       # 'language: python' is an error on Travis CI macOS
       env: PYTHON=3.8
+      before_install:
+        - brew install pyenv
+        - "export PATH=~/.pyenv/bin:$PATH"
+        - "eval '$(pyenv init -)'"
+        - "pyenv install --skip-existing $PYTHON"
+        - "pyenv global $PYTHON"
+        - "pyenv shell $PYTHON"
     - name: "Python 3.6 on macOS"
       os: osx
       osx_image: xcode11.2
       language: shell       # 'language: python' is an error on Travis CI macOS
       env: PYTHON=3.6
       before_install:
-        - brew update
         - brew install pyenv
         - "export PATH=~/.pyenv/bin:$PATH"
         - "eval '$(pyenv init -)'"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ jobs:
       language: shell       # 'language: python' is an error on Travis CI macOS
       env: PYTHON=3.7.4
       before_install:
-        - brew install pyenv
         - "export PATH=~/.pyenv/bin:$PATH"
         - "eval '$(pyenv init -)'"
         - "pyenv install --skip-existing $PYTHON"
@@ -30,7 +29,6 @@ jobs:
       language: shell       # 'language: python' is an error on Travis CI macOS
       env: PYTHON=3.8
       before_install:
-        - brew install pyenv
         - "export PATH=~/.pyenv/bin:$PATH"
         - "eval '$(pyenv init -)'"
         - "pyenv install --skip-existing $PYTHON"
@@ -42,7 +40,6 @@ jobs:
       language: shell       # 'language: python' is an error on Travis CI macOS
       env: PYTHON=3.6
       before_install:
-        - brew install pyenv
         - "export PATH=~/.pyenv/bin:$PATH"
         - "eval '$(pyenv init -)'"
         - "pyenv install --skip-existing $PYTHON"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,29 @@
-os:
-    - linux
-    #- osx
+
 
 language: python
-python:
-    - "3.6"
-    - "3.7"
-    - "3.8"
-
+jobs:
+  include:
+    - name: "Python 3.6.0 on Xenial Linux"
+      python: 3.6           # this works for Linux but is ignored on macOS or Windows
+    - name: "Python 3.7.0 on Xenial Linux"
+      python: 3.7           # this works for Linux but is ignored on macOS or Windows
+    - name: "Python 3.8.0 on Xenial Linux"
+      python: 3.8           # this works for Linux but is ignored on macOS or Windows
+    - name: "Python 3.7.4 on macOS"
+      os: osx
+      osx_image: xcode11.2  # Python 3.7.4 running on macOS 10.14.4
+      language: shell       # 'language: python' is an error on Travis CI macOS
+      env: PYTHON=37
+    - name: "Python 3.8 on macOS"
+      os: osx
+      osx_image: xcode11.2
+      language: shell       # 'language: python' is an error on Travis CI macOS
+      env: PYTHON=38
+    - name: "Python 3.6 on macOS"
+      os: osx
+      osx_image: xcode11.2  
+      language: shell       # 'language: python' is an error on Travis CI macOS
+      env: PYTHON=36
 cache:
     apt: true
     directories:
@@ -20,30 +36,30 @@ addons:
 
 install:
     # Upgrade distribution modules
-    - "pip install --upgrade setuptools"
-    - "pip install --upgrade pip"
+    - "pip3 install --upgrade setuptools"
+    - "pip3 install --upgrade pip"
 
     # Install build dependencies
-    - "pip install wheel"
-    - "pip install --trusted-host www.silx.org -r ci/requirement_travis.txt --upgrade --find-links http://www.silx.org/pub/wheelhouse"
+    - "pip3 install wheel"
+    - "pip3 install --trusted-host www.silx.org -r ci/requirement_travis.txt --upgrade --find-links http://www.silx.org/pub/wheelhouse"
 
     # Print Python info
-    - "python ci/info_platform.py"
-    - "pip freeze"
+    - "python3 ci/info_platform.py"
+    - "pip3 freeze"
 
     # Build
-    - "python setup.py build"
-    - "python setup.py bdist_wheel"
+    - "python3 setup.py build"
+    - "python3 setup.py bdist_wheel"
     - "ls dist"
 
     # Install generated wheel
-    - "pip install --pre --find-links dist/ --trusted-host www.silx.org --find-links http://www.silx.org/pub/wheelhouse freesas"
+    - "pip3 install --pre --find-links dist/ --trusted-host www.silx.org --find-links http://www.silx.org/pub/wheelhouse freesas"
 
 script:
     # Print Python info
-    - "python ci/info_platform.py"
-    - "pip freeze"
+    - "python3 ci/info_platform.py"
+    - "pip3 freeze"
 
     # Run the tests
-    - "python setup.py build test"
-    - "python run_tests.py"
+    - "python3 setup.py build test"
+    - "python3 run_tests.py"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ jobs:
       python: 3.7   # this works for Linux but is ignored on macOS or Windows
     - name: "Python 3.8.0 on Xenial Linux"
       python: 3.8  # this works for Linux but is ignored on macOS or Windows
+    - name: "xcode 10.2 on macOS"
+      os: osx
+      osx_image: xcode10.2
+      language: shell       # 'language: python' is an error on Travis CI macOS
     - name: "xcode 9.4 on macOS"
       os: osx
       osx_image: xcode9.4
@@ -16,10 +20,6 @@ jobs:
     - name: "xcode 11.2 on macOS"
       os: osx
       osx_image: xcode11.2
-      language: shell       # 'language: python' is an error on Travis CI macOS
-    - name: "xcode 10.2 on macOS"
-      os: osx
-      osx_image: xcode10.2
       language: shell       # 'language: python' is an error on Travis CI macOS
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,14 @@ addons:
             - libhdf5-dev
 
 install:
+    #set python version
+    - "pip install -upgrade pip"
+    - "pip install --egg --no-binary pyenv pyenv"
+    - "export PATH=~/.pyenv/bin:$PATH"
+    - "eval '$(pyenv init -)'"
+    - "pyenv install --skip-existing $PYTHON"
+    - "pyenv global $PYTHON"
+    - "pyenv shell $PYTHON"
 
     # Upgrade distribution modules
     - "pip install --upgrade setuptools"
@@ -65,5 +73,5 @@ script:
     - "pip freeze"
 
     # Run the tests
-    - "python3 setup.py build test"
-    - "python3 run_tests.py"
+    - "python setup.py build test"
+    - "python run_tests.py"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,26 +4,29 @@ language: python
 jobs:
   include:
     - name: "Python 3.6.0 on Xenial Linux"
-      python: 3.6           # this works for Linux but is ignored on macOS or Windows
+      python: 3.6
+      env: PYTHON=3.6       # this works for Linux but is ignored on macOS or Windows
     - name: "Python 3.7.0 on Xenial Linux"
-      python: 3.7           # this works for Linux but is ignored on macOS or Windows
+      python: 3.7
+      env: PYTHON=3.7        # this works for Linux but is ignored on macOS or Windows
     - name: "Python 3.8.0 on Xenial Linux"
-      python: 3.8           # this works for Linux but is ignored on macOS or Windows
+      python: 3.8
+      env: PYTHON=3.8        # this works for Linux but is ignored on macOS or Windows
     - name: "Python 3.7.4 on macOS"
       os: osx
       osx_image: xcode11.2  # Python 3.7.4 running on macOS 10.14.4
       language: shell       # 'language: python' is an error on Travis CI macOS
-      env: PYTHON=37
+      env: PYTHON=3.7.4
     - name: "Python 3.8 on macOS"
       os: osx
       osx_image: xcode11.2
       language: shell       # 'language: python' is an error on Travis CI macOS
-      env: PYTHON=38
+      env: PYTHON=3.8
     - name: "Python 3.6 on macOS"
       os: osx
       osx_image: xcode11.2
       language: shell       # 'language: python' is an error on Travis CI macOS
-      env: PYTHON=36
+      env: PYTHON=3.6
 cache:
     apt: true
     directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ addons:
 install:
     #set python version
     - "pip install --upgrade pip"
-    - "pip install --egg --no-binary pyenv pyenv"
+    - "pip install --no-binary pyenv pyenv"
     - "export PATH=~/.pyenv/bin:$PATH"
     - "eval '$(pyenv init -)'"
     - "pyenv install --skip-existing $PYTHON"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,47 +4,26 @@ language: python
 jobs:
   include:
     - name: "Python 3.6.0 on Xenial Linux"
-      python: 3.6
-      env: PYTHON=3.6       # this works for Linux but is ignored on macOS or Windows
+      python: 3.6  # this works for Linux but is ignored on macOS or Windows
     - name: "Python 3.7.0 on Xenial Linux"
-      python: 3.7
-      env: PYTHON=3.7        # this works for Linux but is ignored on macOS or Windows
+      python: 3.7   # this works for Linux but is ignored on macOS or Windows
     - name: "Python 3.8.0 on Xenial Linux"
-      python: 3.8
-      env: PYTHON=3.8        # this works for Linux but is ignored on macOS or Windows
+      python: 3.8  # this works for Linux but is ignored on macOS or Windows
     - name: "Python 3.7.4 on macOS"
       os: osx
       osx_image: xcode11.2  # Python 3.7.4 running on macOS 10.14.4
       language: shell       # 'language: python' is an error on Travis CI macOS
-      env: PYTHON=3.7.4
-      before_install:
-        - "export PATH=~/.pyenv/bin:$PATH"
-        - "eval '$(pyenv init -)'"
-        - "pyenv install --skip-existing $PYTHON"
-        - "pyenv global $PYTHON"
-        - "pyenv shell $PYTHON"
-    - name: "Python 3.8 on macOS"
+    - name: "xcode 11.2 on macOS"
       os: osx
-      osx_image: xcode11.2
+      osx_image: xcode11.2  # Python 3.7.4 running on macOS 10.14.4
       language: shell       # 'language: python' is an error on Travis CI macOS
-      env: PYTHON=3.8
-      before_install:
-        - "export PATH=~/.pyenv/bin:$PATH"
-        - "eval '$(pyenv init -)'"
-        - "pyenv install --skip-existing $PYTHON"
-        - "pyenv global $PYTHON"
-        - "pyenv shell $PYTHON"
-    - name: "Python 3.6 on macOS"
+    - name: "xcode 10.2 on macOS"
       os: osx
-      osx_image: xcode11.2
+      osx_image: xcode10.2  # Python 3.7.4 running on macOS 10.14.4
       language: shell       # 'language: python' is an error on Travis CI macOS
-      env: PYTHON=3.6
-      before_install:
-        - "export PATH=~/.pyenv/bin:$PATH"
-        - "eval '$(pyenv init -)'"
-        - "pyenv install --skip-existing $PYTHON"
-        - "pyenv global $PYTHON"
-        - "pyenv shell $PYTHON"
+
+
+
 cache:
     apt: true
     directories:
@@ -57,30 +36,30 @@ addons:
 
 install:
     # Upgrade distribution modules
-    - "pip install --upgrade setuptools"
-    - "pip install --upgrade pip"
+    - "pip3 install --upgrade setuptools"
+    - "pip3 install --upgrade pip"
 
     # Install build dependencies
-    - "pip install wheel"
-    - "pip install --trusted-host www.silx.org -r ci/requirement_travis.txt --upgrade --find-links http://www.silx.org/pub/wheelhouse"
+    - "pip3 install wheel"
+    - "pip3 install --trusted-host www.silx.org -r ci/requirement_travis.txt --upgrade --find-links http://www.silx.org/pub/wheelhouse"
 
     # Print Python info
-    - "python ci/info_platform.py"
-    - "pip freeze"
+    - "python3 ci/info_platform.py"
+    - "pip3 freeze"
 
     # Build
-    - "python setup.py build"
-    - "python setup.py bdist_wheel"
+    - "python3 setup.py build"
+    - "python3 setup.py bdist_wheel"
     - "ls dist"
 
     # Install generated wheel
-    - "pip install --pre --find-links dist/ --trusted-host www.silx.org --find-links http://www.silx.org/pub/wheelhouse freesas"
+    - "pip3 install --pre --find-links dist/ --trusted-host www.silx.org --find-links http://www.silx.org/pub/wheelhouse freesas"
 
 script:
     # Print Python info
-    - "python ci/info_platform.py"
-    - "pip freeze"
+    - "python3 ci/info_platform.py"
+    - "pip3 freeze"
 
     # Run the tests
-    - "python setup.py build test"
-    - "python run_tests.py"
+    - "python3 setup.py build test"
+    - "python3 run_tests.py"

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ script:
     # Print Python info
     - "python3 ci/info_platform.py"
     - "pip3 freeze"
-    - "python3 -- version"
+    - "python3 --version"
     - "gcc --version"
 
     # Run the tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,14 @@ jobs:
       osx_image: xcode11.2
       language: shell       # 'language: python' is an error on Travis CI macOS
       env: PYTHON=3.6
+      before_install:
+        - brew update
+        - brew install pyenv
+        - "export PATH=~/.pyenv/bin:$PATH"
+        - "eval '$(pyenv init -)'"
+        - "pyenv install --skip-existing $PYTHON"
+        - "pyenv global $PYTHON"
+        - "pyenv shell $PYTHON"
 cache:
     apt: true
     directories:
@@ -38,15 +46,6 @@ addons:
             - libhdf5-dev
 
 install:
-    #set python version
-    - "pip install --upgrade pip"
-    - "pip install --no-binary pyenv pyenv"
-    - "export PATH=~/.pyenv/bin:$PATH"
-    - "eval '$(pyenv init -)'"
-    - "pyenv install --skip-existing $PYTHON"
-    - "pyenv global $PYTHON"
-    - "pyenv shell $PYTHON"
-
     # Upgrade distribution modules
     - "pip install --upgrade setuptools"
     - "pip install --upgrade pip"

--- a/freesas/setup.py
+++ b/freesas/setup.py
@@ -37,7 +37,7 @@ def create_extension_config(name, extra_sources=None, can_use_openmp=False):
     Util function to create numpy extension from the current pyFAI project.
     Prefer using numpy add_extension without it.
     """
-    include_dirs = ['src', numpy.get_include()]
+    include_dirs = [numpy.get_include()]
 
     if can_use_openmp:
         extra_link_args = ['-fopenmp']

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy
 cython
 setuptools
-#matplotlib issue in RTD
+matplotlib
 sphinx
-sphinxcontrib-programoutputsetuptools
+scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy
 cython
 setuptools
-#matplotlib issue in RTD
+matplotlib
 sphinx
 sphinxcontrib-programoutput

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ cython
 setuptools
 #matplotlib issue in RTD
 sphinx
-sphinxcontrib-programoutputsetuptools
+sphinxcontrib-programoutput

--- a/setup.py
+++ b/setup.py
@@ -551,6 +551,7 @@ class BuildExt(build_ext):
             # Avoid empty arg
             ext.extra_link_args = [arg for arg in extra_link_args if arg]
 
+
         elif self.compiler.compiler_type == 'unix':
             # Avoids runtime symbol collision for manylinux1 platform
             # See issue #1070
@@ -608,6 +609,9 @@ class BuildExt(build_ext):
             # Force debug_mode also when it uses python-dbg
             # It is needed for Debian packaging
             debug_mode = self.is_debug_interpreter()
+
+        if sys.platform == "darwin":
+            args.append("-O0")
 
         if self.compiler.compiler_type == "unix":
             args = list(self.compiler.compiler_so)

--- a/setup.py
+++ b/setup.py
@@ -610,8 +610,7 @@ class BuildExt(build_ext):
             # It is needed for Debian packaging
             debug_mode = self.is_debug_interpreter()
 
-        if sys.platform == "darwin":
-            args.append("-O0")
+
 
         if self.compiler.compiler_type == "unix":
             args = list(self.compiler.compiler_so)
@@ -622,6 +621,10 @@ class BuildExt(build_ext):
 
             # always insert symbols
             args.append("-g")
+
+            #On MacOS, we set the optimization level to avoid trouble with AppleClang 10
+            if sys.platform == "darwin":
+                args.append("-O0")
             # only strip asserts in release mode
             if not debug_mode:
                 args.append('-DNDEBUG')

--- a/setup.py
+++ b/setup.py
@@ -35,10 +35,6 @@ import platform
 import shutil
 import logging
 import glob
-# io import has to be here also to fix a bug on Debian 7 with python2.7
-# Without this, the system io module is not loaded from numpy.distutils.
-# The silx.io module seems to be loaded instead.
-import io
 
 if sys.version_info[0] < 3:
     raise SystemError("Freesas requires Python3 !")
@@ -103,7 +99,7 @@ def get_readme():
     """Returns content of README.rst file"""
     dirname = os.path.dirname(os.path.abspath(__file__))
     filename = os.path.join(dirname, "README.md")
-    with io.open(filename, "r", encoding="utf-8") as fp:
+    with open(filename, "r", encoding="utf-8") as fp:
         long_description = fp.read()
     return long_description
 


### PR DESCRIPTION
This pull request 
- starts on dropping python 2 behavior in the setup process (see #1)
- removes some warnings about the lack of "freesas/src" when building extensions 
- added MacOS with Xcode 9,10 and 11 to travis ci
- sets the optimization level on MacOS to O0, which makes Unit Tests pass with Xcode 10 #2 